### PR TITLE
Add icon back button to detail view

### DIFF
--- a/src/components/CompanyDetail.tsx
+++ b/src/components/CompanyDetail.tsx
@@ -1,5 +1,7 @@
 import { Company } from '../lib/types';
 import { Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import './CompanyDetail.css';
 
 interface CompanyDetailProps {
@@ -15,9 +17,11 @@ const CompanyDetail = ({ company }: CompanyDetailProps) => {
       </header>
 
       <div className="back-button-container">
-        <Link to="/" className="back-button">
-          ← Back to Catalog
-        </Link>
+        <Button asChild variant="outline" size="icon">
+          <Link to="/" aria-label="Back to Catalog">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
       </div>
 
       <div className="detail-container">


### PR DESCRIPTION
## Summary
- use ArrowLeft icon from lucide-react in `CompanyDetail`
- render a button with icon linking back to `/`

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-explicit-any' in utils and other lint errors)*