### PR TITLE
Add contacts section to company details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,8 @@ function App() {
             ownership: company.ownership || '',
             ticker: company.ticker || '',
             employeesSite: company.employeesSite || '',
-            sicDescription: company.sicDescription || ''
+            sicDescription: company.sicDescription || '',
+            contacts: company.contacts || []
           }));
         
         setCompanies(processedData);

--- a/src/components/CompanyDetail.css
+++ b/src/components/CompanyDetail.css
@@ -113,7 +113,7 @@
   text-decoration: underline;
 }
 
-.description-section, .additional-section {
+.description-section, .additional-section, .contacts-section {
   background-color: #fff;
   border-radius: 0.5rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -121,7 +121,7 @@
   margin-bottom: 2rem;
 }
 
-.description-section h3, .additional-section h3 {
+.description-section h3, .additional-section h3, .contacts-section h3 {
   font-size: 1.25rem;
   font-weight: 600;
   margin-top: 0;

--- a/src/components/CompanyDetail.tsx
+++ b/src/components/CompanyDetail.tsx
@@ -107,6 +107,24 @@ const CompanyDetail = ({ company }: CompanyDetailProps) => {
             <div className="info-value">{company.tradestyle || 'N/A'}</div>
           </div>
         </div>
+
+        {company.contacts.length > 0 && (
+          <div className="contacts-section">
+            <h3>Contacts</h3>
+            <div className="info-grid wide-grid">
+              {company.contacts.map((contact, index) => (
+                <div key={index} className="contact-row">
+                  <div className="info-label">{contact.name}</div>
+                  <div className="info-value">
+                    {contact.title && <div>{contact.title}</div>}
+                    {contact.email && <div>{contact.email}</div>}
+                    {contact.phone && <div>{contact.phone}</div>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,10 @@
+export interface Contact {
+  name: string;
+  title: string;
+  email: string;
+  phone: string;
+}
+
 export interface Company {
   name: string;
   tradestyle: string;
@@ -18,6 +25,7 @@ export interface Company {
   ticker?: string;
   employeesSite?: string;
   sicDescription?: string;
+  contacts: Contact[];
 }
 
 export interface IndustryOption {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,7 +60,8 @@ export const parseCSVData = (csvData: string) => {
       ownership: company['Ownership Type'] || '',
       ticker: company['Ticker'] || '',
       employeesSite: company['Employees (Single Site)'] || '',
-      sicDescription: company['US 8-Digit SIC Description'] || ''
+      sicDescription: company['US 8-Digit SIC Description'] || '',
+      contacts: []
     };
   }).filter(Boolean);
 };


### PR DESCRIPTION
## Summary
- add `Contact` type and contacts field on `Company`
- include contacts data when parsing CSV and mapping to state
- render company contacts in `CompanyDetail`
- style contacts section like other information panels

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' etc.)*