### PR TITLE
Use Papaparse for CSV parsing

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -18,13 +18,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
-
 let count = 0
 
 function genId() {
@@ -32,23 +25,21 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
   | {
-      type: ActionType["ADD_TOAST"]
+      type: "ADD_TOAST"
       toast: ToasterToast
     }
   | {
-      type: ActionType["UPDATE_TOAST"]
+      type: "UPDATE_TOAST"
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType["DISMISS_TOAST"]
+      type: "DISMISS_TOAST"
       toastId?: ToasterToast["id"]
     }
   | {
-      type: ActionType["REMOVE_TOAST"]
+      type: "REMOVE_TOAST"
       toastId?: ToasterToast["id"]
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,7 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import Papa from "papaparse";
+import type { Company } from "./types";
 
 export interface CompanyData {
   [key: string]: string;
@@ -9,60 +11,34 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const parseCSVData = (csvData: string) => {
-  // CSV parsing logic remains the same
-  const rows = csvData.split('\n');
-  const headers = rows[0].split(',').map(h => h.replace(/"/g, ''));
-  
-  return rows.slice(1).map(row => {
-    if (!row.trim()) return null;
-    
-    // Handle commas within quoted fields
-    const values: string[] = [];
-    let inQuotes = false;
-    let currentValue = '';
-    
-    for (let i = 0; i < row.length; i++) {
-      const char = row[i];
-      
-      if (char === '"') {
-        inQuotes = !inQuotes;
-      } else if (char === ',' && !inQuotes) {
-        values.push(currentValue.replace(/"/g, ''));
-        currentValue = '';
-      } else {
-        currentValue += char;
-      }
-    }
-    
-    values.push(currentValue.replace(/"/g, ''));
-    
-    const company: CompanyData = {};
-    headers.forEach((header, index) => {
-      company[header] = values[index] || '';
-    });
-    
-    return {
-      name: company['Company Name'] || '',
-      tradestyle: company['Tradestyle'] || '',
-      address: company['Address Line 1'] || '',
-      city: company['City'] || '',
-      state: company['State Or Province'] || '',
-      postalCode: company['Postal Code'] || '',
-      phone: company['Phone'] || '',
-      url: company['URL'] || '',
-      sales: company['Sales (USD)'] || '',
-      employees: company['Employees (Total)'] || '',
-      description: company['Business Description'] || '',
-      industry: company['D&B Hoovers Industry'] || '',
-      isHeadquarters: company['Is Headquarters'] === 'true',
-      naicsDescription: company['NAICS 2022 Description'] || '',
-      ownership: company['Ownership Type'] || '',
-      ticker: company['Ticker'] || '',
-      employeesSite: company['Employees (Single Site)'] || '',
-      sicDescription: company['US 8-Digit SIC Description'] || ''
-    };
-  }).filter(Boolean);
+export const parseCSVData = (csvData: string): Company[] => {
+  const { data } = Papa.parse<Record<string, string>>(csvData, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  return (data as Record<string, string>[])
+    .map((row) => ({
+      name: row["Company Name"] || "",
+      tradestyle: row["Tradestyle"] || "",
+      address: row["Address Line 1"] || "",
+      city: row["City"] || "",
+      state: row["State Or Province"] || "",
+      postalCode: row["Postal Code"] || "",
+      phone: row["Phone"] || "",
+      url: row["URL"] || "",
+      sales: row["Sales (USD)"] || "",
+      employees: row["Employees (Total)"] || "",
+      description: row["Business Description"] || "",
+      industry: row["D&B Hoovers Industry"] || "",
+      isHeadquarters: row["Is Headquarters"] === "true",
+      naicsDescription: row["NAICS 2022 Description"] || "",
+      ownership: row["Ownership Type"] || "",
+      ticker: row["Ticker"] || "",
+      employeesSite: row["Employees (Single Site)"] || "",
+      sicDescription: row["US 8-Digit SIC Description"] || "",
+    }))
+    .filter(Boolean);
 };
 
 export const formatSales = (sales: string): string => {
@@ -80,10 +56,10 @@ export const formatSales = (sales: string): string => {
   }
 };
 
-export const getUniqueIndustries = (companies: any[]) => {
+export const getUniqueIndustries = (companies: { industry?: string }[]) => {
   const industries = new Set<string>();
-  
-  companies.forEach((company: any) => {
+
+  companies.forEach((company) => {
     if (company.industry) {
       industries.add(company.industry);
     }


### PR DESCRIPTION
## Summary
- replace custom CSV parser with Papaparse
- tighten industry util typings
- clean up unused type in toast hook

## Testing
- `npm run lint`
